### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# For more information about the properties used in
+# this file, please see the EditorConfig documentation:
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/config/editorconfig.config.rc
+++ b/config/editorconfig.config.rc
@@ -1,0 +1,16 @@
+# For more information about the properties used in
+# this file, please see the EditorConfig documentation:
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,7 @@ function wipe_file_cfg(repo) {
         '.prettierrc.toml',
         '.prettier.config.js',
         'prettier.config.js',
+        '.editorconfig',
     ]
 
     wipe_cfg_list.map(cfg => {
@@ -74,6 +75,10 @@ function configure(repo) {
         [
             path.join(__dirname, '../config/browserslist.config.rc'),
             path.join(repo, '.browserslistrc'),
+        ],
+        [
+            path.join(__dirname, '../config/editorconfig.config.rc'),
+            path.join(repo, '.editorconfig'),
         ],
     ].map(cfg => copy(cfg[0], cfg[1]))
 }


### PR DESCRIPTION
Adds an editorconfig file that matches the settings for prettier. This allows your editor to pick up on the whitespace (etc.) settings for a repo, so there won't be a mismatch for your indentation.

Don't know what you want the file in source to be called. I assumed `editorconfig.config`, but let me know if you prefer otherwise.