### PR TITLE
fix: clean up js filter mechanism

### DIFF
--- a/src/cmds/js_cmds/apply.js
+++ b/src/cmds/js_cmds/apply.js
@@ -1,4 +1,4 @@
-const { collectJsFiles, whitelists, whitelisted } = require('../../files.js')
+const { collectFiles, jsFiles } = require('../../files.js')
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { apply_fmt } = require('../../prettier.js')
@@ -31,19 +31,18 @@ exports.handler = argv => {
 
     let codeFiles
     if (all) {
-        codeFiles = collectJsFiles(root_dir)
+        codeFiles = collectFiles(root_dir)
     } else if (files) {
         codeFiles = files
     } else {
-        const whitelist = whitelisted(whitelists.js)
-        codeFiles = staged_files(root_dir).filter(whitelist)
+        codeFiles = staged_files(root_dir)
     }
 
     // debug information about the folders
     log.debug('rootDir?', root_dir)
     log.debug('codeFiles?', codeFiles)
 
-    const prettyFiles = apply_fmt(codeFiles)
+    const prettyFiles = apply_fmt(jsFiles(codeFiles))
 
     if (prettyFiles.length === 0) {
         log.info('No files to style.')

--- a/src/cmds/js_cmds/check.js
+++ b/src/cmds/js_cmds/check.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { collectJsFiles, whitelists, whitelisted } = require('../../files.js')
+const { collectFiles, jsFiles } = require('../../files.js')
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { check_fmt } = require('../../prettier.js')
@@ -24,19 +24,18 @@ exports.handler = argv => {
 
     let codeFiles
     if (all) {
-        codeFiles = collectJsFiles(root_dir)
+        codeFiles = collectFiles(root_dir)
     } else if (files) {
         codeFiles = files
     } else {
-        const whitelist = whitelisted(whitelists.js)
-        codeFiles = staged_files(root_dir).filter(whitelist)
+        codeFiles = staged_files(root_dir)
     }
 
     // debug information about the folders
     log.debug('rootDir?', root_dir)
     log.debug('codeFiles?', codeFiles)
 
-    const prettyFiles = check_fmt(codeFiles)
+    const prettyFiles = check_fmt(jsFiles(codeFiles))
 
     const success = prettyFiles.length > 0
 

--- a/src/files.js
+++ b/src/files.js
@@ -16,6 +16,11 @@ function whitelisted(whitelist) {
     }
 }
 
+function jsFiles(arr) {
+    const whitelist = whitelisted(whitelists.js)
+    return arr.filter(whitelist)
+}
+
 function collectJsFiles(target) {
     const whitelist = whitelisted(whitelists.js)
     return collectFiles(target).filter(whitelist)
@@ -67,6 +72,7 @@ module.exports = {
     collectFiles,
     collectAllFiles,
     collectJsFiles,
+    jsFiles,
     readFile,
     writeFile,
     whitelisted,


### PR DESCRIPTION
Also stops users from manually passing in `.css`, `.json`, `.md` to prettier by specifying the files as arguments.

Fixes #20 