### PR TITLE
feat: stop auto-install of prettier and other config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ d2-style --help
 d2-style js --help
 d2-style js check --help
 d2-style js apply --help
+d2-style js install --help
 ```
 
 ## Setup for JavaScript project

--- a/src/cmds/js_cmds/apply.js
+++ b/src/cmds/js_cmds/apply.js
@@ -4,8 +4,6 @@ const log = require('@dhis2/cli-helpers-engine').reporter
 const { apply_fmt } = require('../../prettier.js')
 const { stage_files, staged_files } = require('../../git.js')
 
-const configure = require('../../config.js')
-
 exports.command = 'apply [files..]'
 
 exports.describe = 'Apply JS format.'
@@ -52,8 +50,6 @@ exports.handler = argv => {
             log.info('No files to format.')
         }
     }
-
-    configure(root_dir)
 
     if (stage) {
         const stagedFiles = stage_files(prettyFiles, root_dir)

--- a/src/cmds/js_cmds/install.js
+++ b/src/cmds/js_cmds/install.js
@@ -1,0 +1,7 @@
+const configure = require('../../config');
+
+exports.command = "install"
+exports.describe = "Install javascript tool configurations for use by IDE plugins"
+exports.handler = () => {
+    configure(process.cwd())
+}


### PR DESCRIPTION
Instead of auto-installing config files (`.prettierrc.js`, `.browserslistrc`, `.editorconfig`) whenever applying styles (which could be at an arbitrary working directory) install them explicitly with a separate command `d2-style js install`.

Future work:

1. Find-up to get to the nearest `package.json` when installing, rather than using the working directory.
2. Warn of out-of-date configuration when applying styles