### PR TITLE
fix: use eslint linter instead of the cli engine

### DIFF
--- a/src/tools/js/eslint.js
+++ b/src/tools/js/eslint.js
@@ -30,7 +30,7 @@ module.exports = (file, text, apply = false) => {
         const { messages, fixed, output } = linter.verifyAndFix(text, eslintConfig, {
             filename: path.basename(file),
             allowInlineConfig: true,
-            reportUnusedDisableDirectives: true,
+            reportUnusedDisableDirectives: false,
         })
 
         response.fixed = fixed

--- a/src/tools/js/eslint.js
+++ b/src/tools/js/eslint.js
@@ -1,16 +1,18 @@
 const path = require('path')
 const eslint = require('eslint')
+const linter = new eslint.Linter()
 
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { readFile, writeFile } = require('../../files.js')
 
-const eslintConfig = path.join(__dirname, '../../../config/eslint.config.js')
+const eslintConfig = require('../../../config/eslint.config.js')
+
 log.debug('ESLint configuration file', eslintConfig)
 
 /**
- * This a checker used by {run-js} and needs to follow a specific
- * format.
+ * This a checker used by {tools/js/index.js} and needs to follow a
+ * specific format.
  *
  * @param {string} file File path
  * @param {string} text Content of File
@@ -21,32 +23,27 @@ module.exports = (file, text, apply = false) => {
     const response = {
         messages: [],
         output: text,
+        fixed: false,
     }
 
     try {
-        const cli = new eslint.CLIEngine({
-            configFile: eslintConfig,
-            useEslintrc: false,
-            fix: apply,
+        const { messages, fixed, output } = linter.verifyAndFix(text, eslintConfig, {
+            filename: path.basename(file),
             allowInlineConfig: true,
-            ignore: false,
+            reportUnusedDisableDirectives: true,
         })
-        const report = cli.executeOnText(text)
 
-        // when using `executeOnText` the results array always has a
-        // single element
-        const result = report.results[0]
+        response.fixed = fixed
+        response.output = output
 
-        if (result.output) {
-            response.output = result.output
-        }
-
-        for (const message of result.messages) {
+        for (const message of messages) {
+            let rule = ''
+            if (message.ruleId) {
+                rule = `(${message.ruleId})`
+            }
             response.messages.push({
                 checker: 'eslint',
-                message: `Line ${message.line}: ${message.message} (${
-                    message.ruleId
-                })`,
+                message: `Line ${message.line}: ${message.message} ${rule}`,
             })
         }
     } catch (error) {

--- a/src/tools/js/eslint.js
+++ b/src/tools/js/eslint.js
@@ -27,11 +27,15 @@ module.exports = (file, text, apply = false) => {
     }
 
     try {
-        const { messages, fixed, output } = linter.verifyAndFix(text, eslintConfig, {
-            filename: path.basename(file),
-            allowInlineConfig: true,
-            reportUnusedDisableDirectives: false,
-        })
+        const { messages, fixed, output } = linter.verifyAndFix(
+            text,
+            eslintConfig,
+            {
+                filename: path.basename(file),
+                allowInlineConfig: true,
+                reportUnusedDisableDirectives: false,
+            }
+        )
 
         response.fixed = fixed
         response.output = output

--- a/src/tools/js/index.js
+++ b/src/tools/js/index.js
@@ -26,12 +26,16 @@ function runTools(file, apply = false) {
 
     let messages = []
     let source = original
+    let fixed = false
 
     perf.start('exec-file')
     for (const tool of tools) {
         const result = tool(file, source, apply)
 
-        source = result.output
+        if (result.fixed) {
+            source = result.output
+            fixed = result.fixed
+        }
 
         messages = messages.concat(result.messages)
     }
@@ -40,8 +44,8 @@ function runTools(file, apply = false) {
     return {
         file,
         messages,
+        fixed,
         output: source,
-        modified: original !== source,
         name: path.basename(file),
     }
 }
@@ -88,7 +92,6 @@ function print(report, violations) {
     log.info(`${report.length} file(s) checked.`)
 
     if (violations.length > 0) {
-        log.error(`${violations.length} file(s) violate the code standards:`)
         violations.forEach(f => {
             const p = path.relative(process.cwd(), f.file)
             log.info('')
@@ -97,6 +100,7 @@ function print(report, violations) {
         })
 
         log.info('')
+        log.error(`${violations.length} file(s) violate the code standard.`)
     }
 }
 

--- a/src/tools/js/index.js
+++ b/src/tools/js/index.js
@@ -109,7 +109,7 @@ function getViolations(report) {
 }
 
 function getAutoFixable(report) {
-    return report.filter(f => f.modified)
+    return report.filter(f => f.fixed)
 }
 
 /**

--- a/src/tools/js/prettier.js
+++ b/src/tools/js/prettier.js
@@ -24,6 +24,7 @@ module.exports = (file, text, apply = false) => {
     const response = {
         messages: [],
         output: text,
+        fixed: false,
     }
 
     try {
@@ -48,7 +49,9 @@ module.exports = (file, text, apply = false) => {
             })
         }
 
-        if (!apply && text !== response.output) {
+        response.fixed = text !== response.output
+
+        if (!apply && response.fixed) {
             response.messages.push({
                 checker: 'prettier',
                 message: 'Not formatted according to standards.',


### PR DESCRIPTION
This has the primary benefit of letting this instance of ESLint run in isolation from the [ESLint configuration cascade and hierarchy](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy) which can interfere with these standards.

Using only the linter and dealing with the output explicitly allows a project to have a local instance of ESLint for e.g. React 16.8 linting and cli-style for complying with DHIS2 code standards.

This has a secondary benefit of being faster. For maintenance app a full check went from **9.8 sec** to **7.2 sec**.