### PR TITLE
fix(eslint): print a warning when eslint falls back to the built-in

### DIFF
--- a/src/tools/js/eslint.js
+++ b/src/tools/js/eslint.js
@@ -6,6 +6,17 @@ const log = require('@dhis2/cli-helpers-engine').reporter
 const { readFile, writeFile } = require('../../files.js')
 const { CONFIG_ROOT, CONSUMING_ROOT, ESLINT_CONFIG } = require('../../paths.js')
 
+let hasLogged = false
+function fallbackLog(err) {
+    if (!hasLogged) {
+        log.warn(
+            'Could not init ESLint with local config, falling back to built-in (run with --verbose for more info)'
+        )
+        log.debug('Error from local cfg:\n', err)
+        hasLogged = true
+    }
+}
+
 /**
  * This a checker used by {tools/js/index.js} and needs to follow a
  * specific format.
@@ -40,10 +51,7 @@ module.exports = (file, text, apply = false) => {
         report = engine.executeOnFiles([file])
         //log.debug(`Resolved configuration for ${path.basename(file)}`, engine.getConfigForFile(file))
     } catch (err) {
-        log.debug(
-            'Could not init ESLint with local configuration, falling back to built-in. Error from local cfg:\n',
-            err
-        )
+        fallbackLog(err)
 
         const engine = new eslint.CLIEngine({
             ...options,


### PR DESCRIPTION
@HendrikThePendric ran into a situation where `d2-style` silently falls back to the built-in configuration for ESLint, and we spent a little while to figure it out. Turns out I [documented that this can happen](https://github.com/dhis2/cli-style#eslint) but forgot that one has to make a logical jump from "why are not my rule overrides working?" to "i better run this with `--verbose` to figure it out".

And at that point, it does tell your _for each file_ that it is falling back to the built-in, so you get a slew of stack traces to sift through when one would be enough.

This patch introduces a `fallbackLog` function and a module variable to keep track if it has already warned the user about it or not so it only barks once. I don't want to spend too much time on it but if someone has a much better way to do it, feel free to suggest it.

#### Standard run
```
varl@jessika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js check --all
[WARNING] Could not init ESLint with local config, falling back to built-in (run with --verbose for more info) 
37 javascript file(s) checked. 
```

#### Verbose run
```
varl@jessika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js check --all --verbose
[DEBUG] Root directory: /home/varl/dev/dhis2/libs/cli-style 
...
[WARNING] Could not init ESLint with local config, falling back to built-in (run with --verbose for more info) 
[DEBUG] Error from local cfg:
 ReferenceError: Cannot read config file: /home/varl/dev/dhis2/libs/cli-style/.eslintrc.js
Error: asdfa is not defined
    at Object.<anonymous> (/home/varl/dev/dhis2/libs/cli-style/.eslintrc.js:5:5)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at module.exports.moduleId (/home/varl/dev/dhis2/libs/cli-style/node_modules/import-fresh/index.js:28:9)
    at loadJSConfigFile (/home/varl/dev/dhis2/libs/cli-style/node_modules/eslint/lib/config/config-file.js:159:16)
...
37 javascript file(s) checked. 
```