### PR TITLE
fix(eslint): do not add an unignore pattern to the cli command

### DIFF
--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -8,7 +8,6 @@ exports.eslint = ({ files = [], apply = false, config }) => {
         '--no-color',
         '--report-unused-disable-directives',
         '--ignore',
-        ...['--ignore-pattern', '!.*'],
         ...(config ? ['--config', config] : []),
         ...(apply ? ['--fix'] : []),
         ...files,


### PR DESCRIPTION
This overrides any ignores placed in a local .eslintignore file
and thus makes it impossible to ignore hidden files with eslint.