### PR TITLE
feat: use eslint to run prettier

### DIFF
--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -3,6 +3,8 @@ const SEVERITY = 2
 module.exports = {
     extends: ['eslint:recommended', 'prettier'],
 
+    plugins: ['prettier'],
+
     env: {
         browser: true,
         node: true,
@@ -34,5 +36,6 @@ module.exports = {
             },
         ],
         'no-mixed-spaces-and-tabs': [SEVERITY],
+        'prettier/prettier': [SEVERITY],
     },
 }

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,6 +2,7 @@
     -   [Migration guide](migrate-guide)
 -   [**Configuration**](config)
     -   [Ignore files](ignore-files)
+    -   [Override config](overrides)
 -   [**FAQ**](faq)
 -   &nbsp;
 -   [API Reference](api)

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,0 +1,49 @@
+# Configuration overrides
+
+Sometimes you need to override some settings. It should be used
+sparingly as custom style settings runs counter to the goal of a
+consistent style.
+
+Never-the-less. It can be done.
+
+## General
+
+We defer to the local configuration files for each tool, so
+customizations there will be respected when running `d2-style`.
+
+## Prettier
+
+In your project you should have a `.prettierrc.js` file if you used the
+`install` command to set up `d2-style`. In it, you can add any custom
+options _after_ the `...require(config.prettier)` line. For example to
+have semi colons enabled:
+
+```js
+const { config } = require('./index.js')
+
+module.exports = {
+    ...require(config.prettier),
+    semi: true,
+}
+```
+
+## ESLint
+
+Similar to Prettier, you should have a `.eslintrc.js` file in your
+project that you can customize.
+
+E.g. to use another parser, in this case the TypeScript ESLint parser:
+
+```js
+const { config } = require('./index.js')
+
+module.exports = {
+    extends: [config.eslint],
+
+    env: {
+        es6: true,
+    },
+
+    parser: '@typescript-eslint/parser',
+}
+```

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "cross-spawn": "^7.0.1",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.10.0",
+        "eslint-plugin-prettier": "^3.1.2",
         "eslint-plugin-react": "^7.18.0",
         "fast-glob": "^3.1.1",
         "fs-extra": "^8.1.0",

--- a/src/commands/javascript.js
+++ b/src/commands/javascript.js
@@ -2,20 +2,11 @@ const { namespace } = require('@dhis2/cli-helpers-engine')
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { eslint } = require('../tools/eslint.js')
-const { prettier } = require('../tools/prettier.js')
 const { selectFiles } = require('../utils/files.js')
 const { sayFilesChecked, sayNoFiles } = require('../utils/std-log-messages.js')
 
 const options = yargs =>
     yargs
-        .option('prettierConfig', {
-            describe: 'Prettier config file to use',
-            type: 'string',
-        })
-        .option('eslintConfig', {
-            describe: 'ESLint config file to use',
-            type: 'string',
-        })
         .option('pattern', {
             describe:
                 'Pattern to match for files, remember to enclose in double quotes!',
@@ -29,7 +20,7 @@ const options = yargs =>
         })
 
 const handler = (argv, apply) => {
-    const { files, pattern, eslintConfig, prettierConfig, staged } = argv
+    const { files, pattern, staged } = argv
 
     log.info('d2-style > javascript')
 
@@ -47,12 +38,6 @@ const handler = (argv, apply) => {
     log.debug(`Linting files: ${opts.files.join(', ')}`)
 
     eslint({
-        config: eslintConfig,
-        ...opts,
-    })
-
-    prettier({
-        config: prettierConfig,
         ...opts,
     })
 

--- a/src/commands/structured-text.js
+++ b/src/commands/structured-text.js
@@ -7,10 +7,6 @@ const { sayFilesChecked, sayNoFiles } = require('../utils/std-log-messages.js')
 
 const options = yargs =>
     yargs
-        .option('prettierConfig', {
-            describe: 'Prettier config file to use',
-            type: 'string',
-        })
         .option('pattern', {
             describe:
                 'Pattern to match for files, remember to enclose in double quotes!',
@@ -24,7 +20,7 @@ const options = yargs =>
         })
 
 const handler = (argv, apply) => {
-    const { files, pattern, prettierConfig, staged } = argv
+    const { files, pattern, staged } = argv
 
     log.info('d2-style > structured-text')
 
@@ -42,7 +38,6 @@ const handler = (argv, apply) => {
     log.debug(`Linting files: ${opts.files.join(', ')}`)
 
     prettier({
-        config: prettierConfig,
         ...opts,
     })
 

--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -11,6 +11,7 @@ exports.eslint = ({ files = [], apply = false, config }) => {
         '--report-unused-disable-directives',
         '--ignore',
         '--quiet',
+        '--format=unix',
         ...(ignoreFile ? ['--ignore-path', ignoreFile] : []),
         ...(config ? ['--config', config] : []),
         ...(apply ? ['--fix'] : []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,13 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react@^7.18.0:
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz#2317831284d005b30aff8afb7c4e906f13fa8e7e"
@@ -1708,6 +1715,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.1.1"
@@ -3674,6 +3686,13 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^1.19.1:
   version "1.19.1"


### PR DESCRIPTION
This cleans up the log messages and reports that `d2-style js check`
prints:

Before the ESLint and Prettier commands run separately, which is kind of
nice from a technical standpoint of separation, but leads to situations
where we have to first fix the ESLint problems:

```
varl@veronika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js check
d2-style > javascript

/home/varl/dev/dhis2/libs/cli-style/src/index.js
  3:7  error  'foo' is assigned a value but never used  no-unused-vars

✖ 1 problem (1 error, 0 warnings)
```

And then run `js check` again only to get:

```
varl@veronika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js check
d2-style > javascript
src/index.js
[WARNING] Code style issues found in the above file(s).
```

Not too much information about _what_ issues it found either. We can
integrate Prettier with ESLint[1] to combine the steps.

After, we get the ESLint and Prettier problems reported together:

```
varl@veronika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js check
d2-style > javascript
/home/varl/dev/dhis2/libs/cli-style/src/index.js:3:7: 'foo' is assigned a value but never used. [Error/no-unused-vars]
/home/varl/dev/dhis2/libs/cli-style/src/index.js:3:15: Delete `;` [Error/prettier/prettier]
/home/varl/dev/dhis2/libs/cli-style/src/index.js:11:17: Delete `;` [Error/prettier/prettier]
```

Running `js apply`, ESLint will use Prettier to resolve all the problems
it can, leaving those that need manual resolution:

```
varl@veronika:~/dev/dhis2/libs/cli-style$ ./bin/d2-style js apply
d2-style > javascript
/home/varl/dev/dhis2/libs/cli-style/src/index.js:3:7: 'foo' is assigned a value but never used. [Error/no-unused-vars]

1 problem
```

Bonus
-----

This also changes the output to a more compact style that matches closer
to the rest of the tools we have, we can also consider writing our own
custom formatter for ESLint.

[1] https://prettier.io/docs/en/integrating-with-linters.html

BREAKING CHANGE: Deprecate passing in configuration files with
`--prettier-config` and `--eslint-config`. Refer to the "Overrides"
section in the documentation for information how to use custom rules.