### PR TITLE
fix(commands): run commands with yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ are not necessary to explicitly install:
 ## Usage
 
 ```
-npx d2-style --help
+d2-style --help
 
-npx d2-style install --help
+d2-style install --help
 
-npx d2-style js --help
-npx d2-style js check --help
-npx d2-style js apply --help
+d2-style js --help
+d2-style js check --help
+d2-style js apply --help
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ repository for you. For a list of valid groups and what tools they will
 configure, use:
 
 ```bash
-npx d2-style install --list-groups
+d2-style install --list-groups
 ```
 
 If a config file already exists, the tool skips overwriting it, in case
@@ -62,7 +62,7 @@ specification and get the standard
 [EditorConfig](https://editorconfig.org/):
 
 ```
-npx d2-style install project/base
+d2-style install project/base
 
 # * project/base (includes: tools/editorconfig, git/husky)
 ```
@@ -84,7 +84,7 @@ configuration. It does not use any framework specific rules and should
 be applicable to any JavaScript project.
 
 ```
-npx d2-style install project/js
+d2-style install project/js
 
 # * project/js (includes: tools/all, github/all, linter/eslint,
 #   formatter/prettier, git/husky-frontend)
@@ -96,7 +96,7 @@ The `project/react` should be a good starting point for a React project,
 as it adds `eslint-plugin-react`.
 
 ```
-npx d2-style install project/react
+d2-style install project/react
 
 # * project/react (includes: base/all, github/all, linter/eslint-react,
 #   formatter/prettier, git/husky-frontend)

--- a/docs/migrate-guide.md
+++ b/docs/migrate-guide.md
@@ -37,13 +37,13 @@ it, only to install it fresh after.
 
     ```bash
     # no assumption about the project
-    npx d2-style install project/base --force
+    d2-style install project/base --force
 
     # assuming a javascript project
-    npx d2-style install project/js --force
+    d2-style install project/js --force
 
     # assuming a react project
-    npx d2-style install project/react --force
+    d2-style install project/react --force
     ```
 
     (You did take a backup of modified configuration files earlier, right?)

--- a/src/tools/commitlint.js
+++ b/src/tools/commitlint.js
@@ -1,9 +1,9 @@
 const { run } = require('../utils/run.js')
+const { cmd } = require('../utils/cmd.js')
 const { COMMITLINT_CONFIG } = require('../utils/paths.js')
 
 exports.commitlint = (config = COMMITLINT_CONFIG) => {
-    const cmd = 'npx'
-    const args = ['--no-install', 'commitlint', `--config=${config}`, '--edit']
+    const args = ['commitlint', `--config=${config}`, '--edit']
 
     run(cmd, { args })
 }

--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -1,11 +1,10 @@
 const { run } = require('../utils/run.js')
 const { resolveIgnoreFile } = require('../utils/files.js')
+const { cmd } = require('../utils/cmd.js')
 
 exports.eslint = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.eslintignore'])
-    const cmd = 'npx'
     const args = [
-        '--no-install',
         'eslint',
         '--no-color',
         '--report-unused-disable-directives',

--- a/src/tools/prettier.js
+++ b/src/tools/prettier.js
@@ -1,13 +1,12 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { run } = require('../utils/run.js')
+const { cmd } = require('../utils/cmd.js')
 const { resolveIgnoreFile } = require('../utils/files.js')
 
 exports.prettier = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.prettierignore'])
-    const cmd = 'npx'
     const args = [
-        '--no-install',
         'prettier',
         '--list-different',
         ...(config ? ['--config', config] : []),

--- a/src/utils/cmd.js
+++ b/src/utils/cmd.js
@@ -1,0 +1,6 @@
+/**
+ * The command we use to execute the tools.
+ *
+ * Could be `yarn`, `yarn dlx`, or `npx`.
+ */
+exports.cmd = 'yarn'


### PR DESCRIPTION
Use yarn over npx to execute commands, since we use Yarn collectively.

This should solve an issue where the tools cannot be found[1] when
d2 is installed globally with Yarn, and d2-style uses npx to execute the
tools internally.

The dependencies are installed to where Yarn keeps deps, but npx would
look for them in a different place.

[1] https://github.com/dhis2/cli-style/issues/216