### PR TITLE
fix(eslint-import): switch to recommended import settings

### DIFF
--- a/config/js/eslint-react.config.js
+++ b/config/js/eslint-react.config.js
@@ -23,12 +23,5 @@ module.exports = {
             },
         ],
         'react/no-unused-prop-types': 'error',
-        'import/no-unused-modules': [
-            'error',
-            {
-                unusedExports: true,
-                missingExports: false,
-            },
-        ],
     },
 }

--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -1,9 +1,14 @@
 const SEVERITY = 2
 
 module.exports = {
-    extends: ['eslint:recommended', 'prettier'],
+    extends: [
+        'eslint:recommended',
+        'prettier',
+        'plugin:import/errors',
+        'plugin:import/warnings',
+    ],
 
-    plugins: ['prettier', 'import'],
+    plugins: ['prettier'],
 
     env: {
         browser: true,

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -47,3 +47,24 @@ module.exports = {
     parser: '@typescript-eslint/parser',
 }
 ```
+
+Or, if you want to customize the rules, you can enable and disable rules in your local config as well:
+
+```js
+const { config } = require('./index.js')
+
+module.exports = {
+    extends: [config.eslint],
+
+    rules: {
+        // This enables the built-in no-await-in-loop-rule, notifying you with an eslint error
+        'no-await-in-loop': 'error',
+
+        // This enables the 'first' rule of the eslint import plugin, a plugin that ships with
+        // cli-style, notifying you with a warning on any imports that aren't at the top
+        'import/first': 'warning',
+    },
+}
+```
+
+For more information, see: https://eslint.org/docs/user-guide/configuring


### PR DESCRIPTION
This switches to the recommended settings for the eslint import plugin. Their presets are rather conservative (but still very useful), so there shouldn't be anything in here that has to be overridden.

It doesn't add the no-cycle rule, as that rule can be quite resource intensive (it lints node_modules as well by default). We could enable it and ignore node_modules. Then apps could always enable linting that as well if they want it.

Furthermore, this removes the no-unused-modules rule. Viktor and I talked about it in #248. Our conclusion there was to require the user to set ignoreExports (the recommendation in the linked issue). However, if the user has to set that, due to the structure of the rule they basically have to redefine the entire rule anyway. So our shipping the rule isn't very convenient. I think it'd be nicer to just allow them to set it if they want it.

Closes #246 