### PR TITLE
feat(install): prompt to choose project from list

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,9 @@ configure, use:
 npx d2-style install --list-groups
 ```
 
+Run `install` without arguments to get an interactive mode where it is
+possible to choose the project template from a list.
+
 If a config file already exists, the tool skips overwriting it, in case
 there are local modifications.
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "fast-glob": "^3.2.4",
         "fs-extra": "^8.1.0",
         "husky": "^4.3.0",
+        "inquirer": "^7.3.3",
         "perfy": "^1.1.5",
         "prettier": "^1.19.1",
         "semver": "^7.3.2",

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -1,7 +1,8 @@
+const inquirer = require('inquirer')
 const log = require('@dhis2/cli-helpers-engine').reporter
 
 const { configure } = require('../utils/config.js')
-const { printGroups } = require('../utils/groups.js')
+const { printGroups, projects } = require('../utils/groups.js')
 
 exports.command = 'install [group..]'
 
@@ -20,15 +21,34 @@ exports.builder = {
     },
 }
 
-exports.handler = argv => {
+exports.handler = async argv => {
     if (argv.listGroups) {
         log.print(printGroups())
         process.exit(0)
     }
 
+    const prompt = inquirer.createPromptModule()
+
     const { force, group } = argv
 
     const root = process.cwd()
 
-    configure(root, group, force)
+    let choice
+
+    if (!group) {
+        const res = await prompt([
+            {
+                name: 'project',
+                message: 'Choose the project template',
+                type: 'list',
+                choices: () => projects.map(a => a[0]),
+            },
+        ])
+
+        choice = [`project/${res.project}`]
+    } else {
+        choice = group
+    }
+
+    configure(root, choice, force)
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -4,6 +4,18 @@ const log = require('@dhis2/cli-helpers-engine').reporter
 const { configure } = require('../utils/config.js')
 const { printGroups, projects } = require('../utils/groups.js')
 
+const promptForProject = async () => {
+    const res = await inquirer.prompt([
+        {
+            name: 'project',
+            message: 'Choose the project template',
+            type: 'list',
+            choices: () => projects.map(a => a[0]),
+        },
+    ])
+    return [`project/${res.project}`]
+}
+
 exports.command = 'install [group..]'
 
 exports.describe = 'Install DHIS2 configurations for a/all group(s)'
@@ -27,28 +39,10 @@ exports.handler = async argv => {
         process.exit(0)
     }
 
-    const prompt = inquirer.createPromptModule()
-
-    const { force, group } = argv
+    const force = argv.force
+    const group = argv.group || (await promptForProject())
 
     const root = process.cwd()
 
-    let choice
-
-    if (!group) {
-        const res = await prompt([
-            {
-                name: 'project',
-                message: 'Choose the project template',
-                type: 'list',
-                choices: () => projects.map(a => a[0]),
-            },
-        ])
-
-        choice = [`project/${res.project}`]
-    } else {
-        choice = group
-    }
-
-    configure(root, choice, force)
+    configure(root, group, force)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,6 +826,14 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -901,6 +909,11 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -2362,6 +2375,25 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 internal-slot@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.2.tgz#9c2e9fb3cd8e5e4256c6f45fe310067fcfa378a3"
@@ -2981,6 +3013,11 @@ lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 loose-envify@^1.4.0:
   version "1.4.0"
@@ -4092,6 +4129,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
@@ -4101,6 +4143,13 @@ rxjs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
When running `d2 style install` without arguments, an interative prompt
displaying the available projects is displayed:

```
$ d2-style install
? Choose the project template (Use arrow keys)
❯ base
  js
  react
```

To install a custom set of groups, it works the same as before. The
groups are not displayed in the prompt to guide the user to make a safe
choice.

The full list can be seen with `--list-groups` and multiple groups can
be passed in as a space separated list as before.

This feature is kept small and simple in scope to avoid the temptation
to refactor how projects and groups function and tackle that as a
separate task.
