### PR TITLE
fix(eslint): improve 'import/order' config to add newline before internal imports

### DIFF
--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -43,9 +43,13 @@ module.exports = {
         'no-mixed-spaces-and-tabs': [SEVERITY],
         'prettier/prettier': [SEVERITY],
         'import/order': [
-            SEVERITY,
+            'error',
             {
-                'newlines-between': 'never',
+                groups: [
+                    ['external', 'builtin'],
+                    ['index', 'sibling', 'parent', 'internal', 'object'],
+                ],
+                'newlines-between': 'always',
                 alphabetize: {
                     order: 'asc',
                     caseInsensitive: true,

--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -43,7 +43,7 @@ module.exports = {
         'no-mixed-spaces-and-tabs': [SEVERITY],
         'prettier/prettier': [SEVERITY],
         'import/order': [
-            'error',
+            SEVERITY,
             {
                 groups: [
                     ['external', 'builtin'],

--- a/src/commands/commit.js
+++ b/src/commands/commit.js
@@ -1,5 +1,6 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 const { namespace } = require('@dhis2/cli-helpers-engine')
+
 const { commitlint } = require('../tools/commitlint.js')
 
 const commitCmd = yargs => {

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -1,5 +1,6 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 const inquirer = require('inquirer')
+
 const { configure } = require('../utils/config.js')
 const { printGroups, projects } = require('../utils/groups.js')
 

--- a/src/commands/javascript.js
+++ b/src/commands/javascript.js
@@ -1,5 +1,6 @@
 const { namespace } = require('@dhis2/cli-helpers-engine')
 const log = require('@dhis2/cli-helpers-engine').reporter
+
 const { eslint } = require('../tools/eslint.js')
 const { selectFiles } = require('../utils/files.js')
 const { sayFilesChecked, sayNoFiles } = require('../utils/std-log-messages.js')

--- a/src/commands/structured-text.js
+++ b/src/commands/structured-text.js
@@ -1,5 +1,6 @@
 const { namespace } = require('@dhis2/cli-helpers-engine')
 const log = require('@dhis2/cli-helpers-engine').reporter
+
 const { prettier } = require('../tools/prettier.js')
 const { selectFiles } = require('../utils/files.js')
 const { sayFilesChecked, sayNoFiles } = require('../utils/std-log-messages.js')

--- a/src/tools/prettier.js
+++ b/src/tools/prettier.js
@@ -1,4 +1,5 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
+
 const { resolveIgnoreFile } = require('../utils/files.js')
 const { bin } = require('../utils/run.js')
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,6 +1,6 @@
-const path = require('path')
 const log = require('@dhis2/cli-helpers-engine').reporter
 const fs = require('fs-extra')
+const path = require('path')
 
 function copy(from, to, overwrite = true) {
     try {

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -1,7 +1,8 @@
-const path = require('path')
 const log = require('@dhis2/cli-helpers-engine').reporter
 const fg = require('fast-glob')
 const fs = require('fs-extra')
+const path = require('path')
+
 const { CONSUMING_ROOT } = require('./paths.js')
 const { spawn } = require('./run.js')
 

--- a/src/utils/groups.js
+++ b/src/utils/groups.js
@@ -1,4 +1,5 @@
 const path = require('path')
+
 const {
     BROWSERSLIST_CONFIG,
     ESLINT_CONFIG,

--- a/src/utils/run.js
+++ b/src/utils/run.js
@@ -1,6 +1,7 @@
-const path = require('path')
 const spawn = require('cross-spawn')
 const findup = require('find-up')
+const path = require('path')
+
 const { PACKAGE_ROOT } = require('./paths.js')
 
 exports.spawn = (cmd, args, opts) =>

--- a/tests/configs.js
+++ b/tests/configs.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const test = require('tape')
+
 const { config } = require('../index.js')
 
 test('prettier config resolves to non-empty object', t => {

--- a/tests/group-resolution.js
+++ b/tests/group-resolution.js
@@ -1,4 +1,5 @@
 const test = require('tape')
+
 const {
     groups,
     projects,

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,4 +1,5 @@
 const test = require('tape')
+
 const { command, config } = require('../index.js')
 
 test('base exports are objects', t => {


### PR DESCRIPTION
I prefer this config because:
- This creates two main groups, basically "internal" vs "others"
- Between these two groups we'll get a newline

Current sort result:
```
import i18n from '@dhis2/d2-i18n'
import propTypes from '@dhis2/prop-types'
import MailIcon from 'material-ui-icons/MailOutline'
import Subheader from 'material-ui/Subheader/Subheader'
import React, { Component } from 'react'
import { connect } from 'react-redux'
import { compose } from 'recompose'
import Toolbar from '../Common/Toolbar'
import MessageConversationList from '../List/MessageConversationList'
import SidebarList from '../List/SidebarList'
import CreateMessage from '../MessageConversation/CreateMessage'
import MessageConversation from '../MessageConversation/MessageConversation'
import './MessagingCenter.css'
```

Improved sort result:
```
import i18n from '@dhis2/d2-i18n'
import propTypes from '@dhis2/prop-types'
import MailIcon from 'material-ui-icons/MailOutline'
import Subheader from 'material-ui/Subheader/Subheader'
import React, { Component } from 'react'
import { connect } from 'react-redux'
import { compose } from 'recompose'

import Toolbar from '../Common/Toolbar'
import MessageConversationList from '../List/MessageConversationList'
import SidebarList from '../List/SidebarList'
import CreateMessage from '../MessageConversation/CreateMessage'
import MessageConversation from '../MessageConversation/MessageConversation'
import './MessagingCenter.css'
```

FYI: this is a PR against `alpha`.