### PR TITLE
fix: resolve relative paths to staged files

### DIFF
--- a/.github/workflows/dhis2-verify-node.yml
+++ b/.github/workflows/dhis2-verify-node.yml
@@ -1,18 +1,6 @@
 name: 'dhis2: verify (node)'
 
-on:
-    push:
-        branches:
-            # match branches in:
-            # https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches
-            - master
-            - next
-            - next-major
-            - alpha
-            - beta
-            - '[0-9]+.x'
-            - '[0-9]+.x.x'
-            - '[0-9]+.[0-9]+.x'
+on: push
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -145,7 +145,10 @@ const stagedFiles = (files = []) => {
     const output = result.stdout.trim()
 
     if (output) {
-        const staged = output.split('\n')
+        const staged = output
+            .split('\n')
+            .map(f => path.resolve(CONSUMING_ROOT, f))
+
         return files.filter(f => staged.includes(f))
     }
 


### PR DESCRIPTION
This fixes instances where there are staged changes, but they aren't
picked up with using the `--staged` flag.

After moving to gathering files with absolute paths, we must construct
absolute paths for the files reported as changed by Git that were listed
as relative.
