### PR TITLE
fix: update bin lookup to avoid assuming node_modules lookup

### DIFF
--- a/src/tools/commitlint.js
+++ b/src/tools/commitlint.js
@@ -2,9 +2,9 @@ const { bin } = require('../utils/run.js')
 const { COMMITLINT_CONFIG } = require('../utils/paths.js')
 
 exports.commitlint = (config = COMMITLINT_CONFIG) => {
-    const package = '@commitlint/cli'
-    const bin = 'commitlint'
+    const packageName = '@commitlint/cli'
+    const cmd = 'commitlint'
     const args = ['commitlint', `--config=${config}`, '--edit']
 
-    bin(package, { bin, args })
+    bin(packageName, { bin: cmd, args })
 }

--- a/src/tools/commitlint.js
+++ b/src/tools/commitlint.js
@@ -2,8 +2,9 @@ const { bin } = require('../utils/run.js')
 const { COMMITLINT_CONFIG } = require('../utils/paths.js')
 
 exports.commitlint = (config = COMMITLINT_CONFIG) => {
-    const cmd = 'commitlint'
+    const package = '@commitlint/cli'
+    const bin = 'commitlint'
     const args = ['commitlint', `--config=${config}`, '--edit']
 
-    bin(cmd, { args })
+    bin(package, { bin, args })
 }

--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -4,7 +4,7 @@ const { PACKAGE_ROOT } = require('../utils/paths.js')
 
 exports.eslint = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.eslintignore'])
-    const package = 'eslint'
+    const packageName = 'eslint'
     const args = [
         '--no-color',
         '--report-unused-disable-directives',
@@ -18,5 +18,5 @@ exports.eslint = ({ files = [], apply = false, config }) => {
         ...files,
     ]
 
-    bin(package, { args })
+    bin(packageName, { args })
 }

--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -4,7 +4,7 @@ const { PACKAGE_ROOT } = require('../utils/paths.js')
 
 exports.eslint = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.eslintignore'])
-    const cmd = 'eslint'
+    const package = 'eslint'
     const args = [
         '--no-color',
         '--report-unused-disable-directives',
@@ -18,5 +18,5 @@ exports.eslint = ({ files = [], apply = false, config }) => {
         ...files,
     ]
 
-    bin(cmd, { args })
+    bin(package, { args })
 }

--- a/src/tools/prettier.js
+++ b/src/tools/prettier.js
@@ -5,7 +5,7 @@ const { resolveIgnoreFile } = require('../utils/files.js')
 
 exports.prettier = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.prettierignore'])
-    const package = 'prettier'
+    const packageName = 'prettier'
     const args = [
         '--list-different',
         ...(config ? ['--config', config] : []),
@@ -14,7 +14,7 @@ exports.prettier = ({ files = [], apply = false, config }) => {
         ...files,
     ]
 
-    bin(package, { args }, ({ status }) => {
+    bin(packageName, { args }, ({ status }) => {
         if (status === 1 && !apply) {
             log.warn(`Code style issues found in the above file(s).`)
         }

--- a/src/tools/prettier.js
+++ b/src/tools/prettier.js
@@ -5,7 +5,7 @@ const { resolveIgnoreFile } = require('../utils/files.js')
 
 exports.prettier = ({ files = [], apply = false, config }) => {
     const ignoreFile = resolveIgnoreFile(['.prettierignore'])
-    const cmd = 'prettier'
+    const package = 'prettier'
     const args = [
         '--list-different',
         ...(config ? ['--config', config] : []),
@@ -14,7 +14,7 @@ exports.prettier = ({ files = [], apply = false, config }) => {
         ...files,
     ]
 
-    bin(cmd, { args }, ({ status }) => {
+    bin(package, { args }, ({ status }) => {
         if (status === 1 && !apply) {
             log.warn(`Code style issues found in the above file(s).`)
         }


### PR DESCRIPTION
This works in both yarn1 and yarn2 environments, and should be more robust against (for instance) transitive dependencies which don't get their executables hoisted to the top-level `node_modules/.bin` (which is the case in yarn2 - transitive dependencies aren't available with `yarn run`)

The main downside here is that it assumes the `bin` file is a `node` script - this is also the behavior of yarn's own `run` command, so it _should_ be OK - we're also only using Node scripts from dependencies in `cli-stye` so far, so it should be fine for now.  The challenge with supporting non-node scripts is that they can't be run directly from within a .zip file (where they exist in yarn2), so we need to run `yarn node` to be able to resolve plug-and-play files and dependencies.