### PR TITLE
feat(eslint): add i18n eslint plugin

### DIFF
--- a/config/js/eslint-react.config.js
+++ b/config/js/eslint-react.config.js
@@ -18,7 +18,7 @@ module.exports = {
     rules: {
         'i18next/no-literal-string': [
             'warn',
-            { markupOnly: true, onlyAttribute: [''] },
+            { markupOnly: true, onlyAttribute: ['label'] },
         ],
         'react/sort-prop-types': [
             'error',

--- a/config/js/eslint-react.config.js
+++ b/config/js/eslint-react.config.js
@@ -1,6 +1,8 @@
 module.exports = {
     parser: 'babel-eslint',
 
+    plugins: ['i18next'],
+
     extends: [
         './eslint.config.js',
         'plugin:react/recommended',
@@ -14,6 +16,10 @@ module.exports = {
     },
 
     rules: {
+        'i18next/no-literal-string': [
+            'warn',
+            { markupOnly: true, onlyAttribute: [''] },
+        ],
         'react/sort-prop-types': [
             'error',
             {
@@ -24,4 +30,13 @@ module.exports = {
         ],
         'react/no-unused-prop-types': 'error',
     },
+
+    overrides: [
+        {
+            files: ['*.test.js', '**/__tests__/*.js'],
+            rules: {
+                'i18next/no-literal-string': 'off',
+            },
+        },
+    ],
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "cross-spawn": "^7.0.3",
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^7.2.0",
+        "eslint-plugin-i18next": "^5.0.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-react": "^7.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,13 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-i18next@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-i18next/-/eslint-plugin-i18next-5.0.0.tgz#e87cf6a42603ed1513b87a3de91104d55ae5da50"
+  integrity sha512-ixbgSMrSb0dZsO6WPElg4JvPiQKLDA3ZpBuayxToADan1TKcbzKXT2A42Vyc0lEDhJRPL6uZnmm8vPjODDJypg==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
@@ -4336,6 +4343,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requizzle@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
See this slack thread: https://dhis2.slack.com/archives/CPGUFVC56/p1615363540343500

This adds https://github.com/edvardchen/eslint-plugin-i18next, which warns on untranslated strings in jsx. The settings are what I've been using in the scheduler. We could tweak them a bit more later on, and for example add linting of certain attributes as well. I'm ignoring this rule for test files, as react components defined in test files won't be shipped to the end user.

I've set it to warn initially so that it's not a breaking change and to allow us to try it out first. Once we're happy with it we could move it to error and fine-tune the rule.