### PR TITLE
feat(eslint): add react hooks plugin configuration

### DIFF
--- a/config/eslint-react.config.js
+++ b/config/eslint-react.config.js
@@ -1,6 +1,8 @@
 module.exports = {
     parser: 'babel-eslint',
 
+    plugins: ['react-hooks'],
+
     extends: [
         './eslint.config.js',
         'plugin:react/recommended',
@@ -14,6 +16,8 @@ module.exports = {
     },
 
     rules: {
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
         'react/sort-prop-types': [
             'error',
             {


### PR DESCRIPTION
This adds config for the react-hooks eslint plugin. The plugin already ships with CRA, so all I've done is enable it:

<img width="630" alt="Screenshot 2021-03-10 at 11 02 01" src="https://user-images.githubusercontent.com/7355199/110612423-77327000-8190-11eb-8877-812783bc329a.png">

I've set exhaustive-deps to warn. Initially there were some false positives for this rule that meant an error wasn't always correct: https://github.com/facebook/react/issues/14920. Though that issue has since been closed, so maybe it's safe to set to error. There are some related issues open: https://github.com/facebook/react/issues?q=is%3Aissue+is%3Aopen+exhaustive, but maybe setting it to error and just expecting the user to disable when necessary is good enough.