### PR TITLE
feat: strict mode for warnings

### DIFF
--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -1,5 +1,3 @@
-const SEVERITY = 2
-
 module.exports = {
     extends: [
         'eslint:recommended',
@@ -7,6 +5,9 @@ module.exports = {
         'plugin:import/errors',
         'plugin:import/warnings',
     ],
+
+    // unignore implicit rules about what types of files can be linted
+    ignorePatterns: ['!.*'],
 
     plugins: ['prettier'],
 
@@ -28,22 +29,22 @@ module.exports = {
 
     rules: {
         'max-params': [
-            SEVERITY,
+            'error',
             {
                 max: 3,
             },
         ],
         'prefer-const': [
-            SEVERITY,
+            'error',
             {
                 destructuring: 'any',
                 ignoreReadBeforeAssign: false,
             },
         ],
-        'no-mixed-spaces-and-tabs': [SEVERITY],
-        'prettier/prettier': [SEVERITY],
+        'no-mixed-spaces-and-tabs': ['error'],
+        'prettier/prettier': ['error'],
         'import/order': [
-            SEVERITY,
+            'error',
             {
                 'newlines-between': 'never',
                 alphabetize: {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 Some wisdom from Go:
 
-> Gofmt's style is no one's favorite, yet gofmt is everyone's favorite.
+> `gofmt`'s style is no one's favorite, yet `gofmt` is everyone's favorite.
 
 # I'm getting husky errors
 
@@ -14,3 +14,31 @@ You can reinstall it using 'npm install husky --save-dev' or delete this hook
 ```
 
 Ensure that your node and git versions satisfy the above requirements. You can check this by running `git --version` and `node --version` from your terminal.
+
+# What does an Error and Warnings mean?
+
+`d2-style` is strict by default, as it tries to guard against known lint
+from entering the codebase. If the lint is denied early, it is easier,
+and faster, to fix it.
+
+We set most our style rules to `error` to serve this purpose. This works
+best when `d2-style` is added to a project that doesn't have a lot of
+code yet.
+
+It is not fun to add `d2-style` when the codebase has grown and
+accumulated what is considered lint. Everything as errors means that it
+will take real effort to de-lint the codebase.
+
+It is also not fun when `d2-style` decides to adopt new rules as errors.
+That means by simply updating `d2-style` the codebase can be in need of
+significant clean-ups.
+
+So `d2-style` operates with two levels: `--strict` and `--no-strict`.
+
+In both modes, errors are considered problems significant enough that
+they cannot be allowed into the code base.
+
+In strict mode, warnings are NOT allowed into the code base.
+
+In the non-strict mode, warnings are allowed into the code base and can
+be used as an interim solution to allow for planned de-linting.

--- a/src/tools/eslint.js
+++ b/src/tools/eslint.js
@@ -9,7 +9,6 @@ exports.eslint = ({ files = [], apply = false, config }) => {
         '--no-color',
         '--report-unused-disable-directives',
         '--ignore',
-        '--quiet',
         '--format=unix',
         `--resolve-plugins-relative-to=${PACKAGE_ROOT}`,
         ...(ignoreFile ? ['--ignore-path', ignoreFile] : []),


### PR DESCRIPTION
Allow d2-style to print warnings from ESLint and introduce a concept of
strict and non-strict modes.

Strict mode: Set a zero tolerance on warnings by making ESLint exit with
a non-zero code if there are any warnings. Warnings will be shown in
strict mode.

Non-strict mode: Allow ESLint to exit with code zero when there are
warnings. Warnings are essentially ignored in this mode which matches
the behavior today.

This allows gradual introduction of new rules, that may later become
errors.

In strict mode a developer is expected to either:

a)  fix the warning
b)  explicitly mark the code that triggered the warning with an
eslint-disable comment.

A good disable directive uses the comment syntax for ESLint:

    /* eslint-disable [rule] -- [comment] */

E.g.

    /* eslint-disable-next-line no-console -- we need to log here */

When rules graduate from "warning" to "error" the code base should be
ready for the change.