### PR TITLE
feat: improve file name matching

### DIFF
--- a/config/d2-style.config.js
+++ b/config/d2-style.config.js
@@ -11,7 +11,7 @@ module.exports = {
         commitlint: [],
     },
     patterns: {
-        js: '**/*.{js,jsx,ts,tsx}',
-        text: '**/*.{md,json,yml,html}',
+        js: '*.{js,jsx,ts,tsx}',
+        text: '*.{md,json,yml,html}',
     },
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "husky": "^5.2.0",
+        "micromatch": "^4.0.4",
         "perfy": "^1.1.5",
         "prettier": "^2.2.1",
         "semver": "^7.3.4",

--- a/src/commands/types/javascript.js
+++ b/src/commands/types/javascript.js
@@ -45,11 +45,9 @@ exports.handler = (argv, callback) => {
     const jsFiles = selectFiles(files, jsPattern, staged)
 
     if (jsFiles.length === 0) {
-        log.warn(sayNoFiles('javascript', jsPattern, staged))
+        log.debug(sayNoFiles('javascript', jsPattern, staged))
         return
     }
-
-    log.debug(`Linting files: ${jsFiles.join(', ')}`)
 
     log.info('javascript > eslint')
     eslint({

--- a/src/commands/types/structured-text.js
+++ b/src/commands/types/structured-text.js
@@ -40,7 +40,7 @@ exports.handler = (argv, callback) => {
 
     const textFiles = selectFiles(files, textPattern, staged)
     if (textFiles.length === 0) {
-        log.warn(sayNoFiles('structured text', textPattern, staged))
+        log.debug(sayNoFiles('structured text', textPattern, staged))
         return
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,6 +3289,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 mime-db@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
@@ -3831,6 +3839,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
Allows the user to pass directory, filenames, and globs to the "check"
and "apply" commands:

    yarn d2-style check *.js
    yarn d2-style check .
    yarn d2-style check src
    yarn d2-style check src/**/*.spec.js

Note that the first example "*.js" means that basename matching is
enabled so that if a file has a '/' in the path, it will still be a
successful match.

This allows us to simplify the patterns in d2style.config.js by saying
that:

    patterns.js = '*.js'

Instead of:

    patterns.js = '**/*.js'

On the question why we aren't just passing along the argument as-is to
eslint and prettier (they support "dir|file|glob" in their clis) the
answer is two-fold:

    1.  We want to control which files are passed to the tool to avoid
        e.g. Prettier checking non-js files that it supports when we run
        "check js" for example.

    2.  We want to be able to only run checks against staged files,
        which means we have to filter out unstaged files from the list
        of files we pass to each tool.