### PR TITLE
fix(cli-43): skip git ops when not a git repo

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -2,6 +2,7 @@ const path = require('path')
 const log = require('@dhis2/cli-helpers-engine').reporter
 const { husky, isSupportedHook } = require('../tools/husky.js')
 const { fileExists, deleteFile } = require('../utils/files.js')
+const { gitEnabled } = require('../utils/git.js')
 const { PROJECT_HOOKS_DIR, DEPRECATED_CONFIGS } = require('../utils/paths.js')
 const { callback, exit } = require('../utils/run.js')
 
@@ -41,7 +42,7 @@ exports.installcmd = yargs =>
                 }
             }
 
-            if (config.hooks) {
+            if (gitEnabled() && config.hooks) {
                 log.info('git-hooks > husky')
                 husky({
                     command: 'install',

--- a/src/commands/types/commit.js
+++ b/src/commands/types/commit.js
@@ -1,5 +1,6 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 const { commitlint } = require('../../tools/commitlint.js')
+const { gitEnabled } = require('../../utils/git.js')
 const { CONSUMING_ROOT } = require('../../utils/paths.js')
 const { callback, exit } = require('../../utils/run.js')
 
@@ -23,6 +24,12 @@ exports.builder = yargs =>
 
 exports.handler = argv => {
     log.info(`commit-msg > commitlint`)
+
+    if (!gitEnabled()) {
+        log.print('Not a Git repository, skipping commit validation.')
+        return
+    }
+
     commitlint({
         config: argv.commitlintConfig,
         file: argv.file,

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -188,6 +188,8 @@ const pickFirstExists = (files = [], customRoot) => {
 
 const fileExists = fp => fs.existsSync(fp) && fs.statSync(fp).size !== 0
 
+const dirExists = fp => fs.existsSync(fp) && fs.statSync(fp).isDirectory()
+
 const resolveIgnoreFile = (ignoreFiles = []) => {
     return pickFirstExists([...ignoreFiles, '.d2styleignore', '.gitignore'])
 }
@@ -209,5 +211,6 @@ module.exports = {
     pickFirstExists,
     resolveIgnoreFile,
     fileExists,
+    dirExists,
     relativePath,
 }

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -1,0 +1,4 @@
+const { dirExists } = require('./files.js')
+const { GIT_DIR } = require('./paths.js')
+
+exports.gitEnabled = () => dirExists(GIT_DIR)

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -13,8 +13,7 @@ const PROJECT_ROOT = findup.sync(
             '.git',
             '.github',
             'yarn.lock',
-            'package.json',
-            '.d2',
+            'package-lock.json',
         ].map(i => findup.sync.exists(path.join(directory, i)))
         return amiroot.includes(true) && directory
     },

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -9,9 +9,13 @@ const TEMPLATE_DIR = path.join(PACKAGE_ROOT, 'templates')
 
 const PROJECT_ROOT = findup.sync(
     directory => {
-        const amiroot = ['.git', '.github', '.d2'].map(i =>
-            findup.sync.exists(path.join(directory, i))
-        )
+        const amiroot = [
+            '.git',
+            '.github',
+            'yarn.lock',
+            'package.json',
+            '.d2',
+        ].map(i => findup.sync.exists(path.join(directory, i)))
         return amiroot.includes(true) && directory
     },
     {
@@ -19,6 +23,8 @@ const PROJECT_ROOT = findup.sync(
         type: 'directory',
     }
 )
+
+const GIT_DIR = path.join(PROJECT_ROOT, '.git')
 const PROJECT_HOOKS_DIR = path.join(PROJECT_ROOT, '.hooks')
 
 const STYLE_CONFIG_FILES = ['d2-style.config.js', 'd2-style.js']
@@ -34,4 +40,5 @@ module.exports = {
     PROJECT_ROOT,
     TEMPLATE_DIR,
     DEPRECATED_CONFIGS,
+    GIT_DIR,
 }


### PR DESCRIPTION
Introduce a gitEnabled() function used to identify if Git operations
like linting commits and installing hooks should be done.

Modifies how the PROJECT_ROOT is identified when there is no .git
directory by adding additional root-level files like yarn.lock and
package-lock.json.

Jira-Issue: CLI-43
