### PR TITLE
feat(tools): adds add/remove commands for tools

### DIFF
--- a/src/commands/actions/editorconfig.js
+++ b/src/commands/actions/editorconfig.js
@@ -1,35 +1,38 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 const cfg = require('../../utils/config.js')
 
-exports.command = 'eslint [type]'
+exports.command = 'editorconfig [type]'
 
-exports.desc = 'Add ESLint configuration to the project.'
+exports.desc = 'Add the editorconfig configuration to the project.'
 
 exports.builder = yargs =>
     yargs
         .positional('type', {
-            describe: 'Configuration template for ESLint.',
+            describe: 'Template to use for EditorConfig',
             type: 'string',
-            choices: Object.keys(cfg.templateConfigs.eslint),
             default: 'base',
         })
         .option('overwrite', {
             describe: 'Overwrite the existing configuration.',
             type: 'boolean',
         })
+        .example(
+            '$0 add editorconfig',
+            'Adds the standard configuration to .editorconfig'
+        )
 
 exports.handler = argv => {
     const { add, type, overwrite } = argv
 
-    log.info(`eslint > ${add ? 'add' : 'remove'}`)
+    log.info(`editorconfig > ${add ? 'add' : 'remove'}`)
 
     if (add) {
         cfg.add({
-            tool: 'eslint',
-            type,
+            tool: 'editorconfig',
+            type: type ? type : 'base',
             overwrite,
         })
     } else {
-        cfg.remove({ tool: 'eslint', type })
+        cfg.remove({ tool: 'editorconfig', type: type ? type : 'base' })
     }
 }

--- a/src/commands/actions/git-hook.js
+++ b/src/commands/actions/git-hook.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const log = require('@dhis2/cli-helpers-engine').reporter
-const { husky } = require('../../tools/husky.js')
+const { husky, supportedHooks } = require('../../tools/husky.js')
 const { remove } = require('../../utils/config.js')
 const { CONSUMING_ROOT, PROJECT_HOOKS_DIR } = require('../../utils/paths.js')
 
@@ -12,22 +12,32 @@ const defaultCommand = type =>
 
 exports.command = 'git-hook <type> [command]'
 
-exports.desc = ''
+exports.desc = 'Add Git Hooks to the project.'
 
 exports.builder = yargs =>
     yargs
         .positional('type', {
-            describe: '',
+            describe: 'Git Hook to register a command against.',
             type: 'string',
+            choices: supportedHooks,
         })
         .positional('command', {
-            describe: '',
+            describe:
+                'The command the hook will trigger. Remember it must be enclosed in quotes.',
             type: 'string',
         })
         .option('overwrite', {
-            describe: '',
+            describe: 'Overwrite the existing configuration.',
             type: 'boolean',
         })
+        .example(
+            '$0 add git-hook pre-push "yarn test"',
+            'Adds a pre-push git hook that runs the command "yarn test".'
+        )
+        .example(
+            '$0 add git-hook pre-commit "yarn d2-style apply --staged"',
+            'Applies code style to staged files before committing.'
+        )
 
 exports.handler = argv => {
     const { add, type, command, overwrite } = argv

--- a/src/commands/actions/github.js
+++ b/src/commands/actions/github.js
@@ -1,0 +1,43 @@
+const log = require('@dhis2/cli-helpers-engine').reporter
+const cfg = require('../../utils/config.js')
+
+exports.command = 'github <type>'
+
+exports.desc = 'Add configuration files for GitHub'
+
+exports.builder = yargs =>
+    yargs
+        .positional('type', {
+            describe: 'Template to use for GitHub configuration',
+            type: 'string',
+            choices: Object.keys(cfg.templateConfigs.github),
+        })
+        .option('overwrite', {
+            describe: 'Overwrite the existing configuration.',
+            type: 'boolean',
+        })
+        .example(
+            '$0 add github workflow-node',
+            'Adds the GitHub Workflow template for NodeJS projects'
+        )
+        .example(
+            '$0 add github dependabot',
+            'Adds the configuration file for Dependabot with DHIS2 defaults'
+        )
+
+exports.handler = argv => {
+    const { add, type, overwrite, getCache } = argv
+
+    log.info(`github > ${add ? 'add' : 'remove'}`)
+
+    if (add) {
+        cfg.add({
+            tool: 'github',
+            type,
+            cache: getCache(),
+            overwrite,
+        })
+    } else {
+        cfg.remove({ tool: 'github', type })
+    }
+}

--- a/src/commands/actions/ls-lint.js
+++ b/src/commands/actions/ls-lint.js
@@ -8,14 +8,18 @@ exports.desc = 'Lint file and directory names.'
 exports.builder = yargs =>
     yargs
         .positional('type', {
-            describe: '',
+            describe: 'Configuration template to use for ls-lint',
             type: 'string',
+            default: 'base',
         })
         .option('overwrite', {
-            describe: '',
+            describe: 'Overwrite the existing configuration.',
             type: 'boolean',
         })
-        .example('$0', 'Adds the standard configuration to .ls-lint.yml')
+        .example(
+            '$0 add ls-lint',
+            'Adds the standard configuration to .ls-lint.yml'
+        )
 
 exports.handler = argv => {
     const { add, type, overwrite } = argv
@@ -23,13 +27,12 @@ exports.handler = argv => {
     log.info(`ls-lint > ${add ? 'add' : 'remove'}`)
 
     if (add) {
-        const template = type ? type : 'base'
         cfg.add({
             tool: 'lslint',
-            template,
+            type: type ? type : 'base',
             overwrite,
         })
     } else {
-        cfg.remove({ tool: 'lslint', type })
+        cfg.remove({ tool: 'lslint', type: type ? type : 'base' })
     }
 }

--- a/src/commands/actions/prettier.js
+++ b/src/commands/actions/prettier.js
@@ -1,35 +1,38 @@
 const log = require('@dhis2/cli-helpers-engine').reporter
 const cfg = require('../../utils/config.js')
 
-exports.command = 'eslint [type]'
+exports.command = 'prettier [type]'
 
-exports.desc = 'Add ESLint configuration to the project.'
+exports.desc = 'Add the Prettier configuration to the project.'
 
 exports.builder = yargs =>
     yargs
         .positional('type', {
-            describe: 'Configuration template for ESLint.',
+            describe: 'Configuration template to use for Prettier',
             type: 'string',
-            choices: Object.keys(cfg.templateConfigs.eslint),
             default: 'base',
         })
         .option('overwrite', {
             describe: 'Overwrite the existing configuration.',
             type: 'boolean',
         })
+        .example(
+            '$0 add prettier',
+            'Adds the standard configuration to .prettierrc.js'
+        )
 
 exports.handler = argv => {
     const { add, type, overwrite } = argv
 
-    log.info(`eslint > ${add ? 'add' : 'remove'}`)
+    log.info(`prettier > ${add ? 'add' : 'remove'}`)
 
     if (add) {
         cfg.add({
-            tool: 'eslint',
-            type,
+            tool: 'prettier',
+            type: type ? type : 'base',
             overwrite,
         })
     } else {
-        cfg.remove({ tool: 'eslint', type })
+        cfg.remove({ tool: 'prettier', type: type ? type : 'base' })
     }
 }

--- a/src/tools/husky.js
+++ b/src/tools/husky.js
@@ -1,47 +1,22 @@
 const { join } = require('path')
 const { bin } = require('@dhis2/cli-helpers-engine').exec
-const { exit } = require('@dhis2/cli-helpers-engine')
 const { PACKAGE_ROOT, PROJECT_HOOKS_DIR } = require('../utils/paths.js')
 
-// https://git-scm.com/docs/githooks
-const supportedHooks = [
-    'applypatch-msg',
-    'pre-applypatch',
-    'post-applypatch',
+// subset of https://git-scm.com/docs/githooks
+exports.supportedHooks = [
     'pre-commit',
-    'pre-merge-commit',
-    'prepare-commit-msg',
     'commit-msg',
     'post-commit',
-    'pre-rebase',
     'post-checkout',
     'post-merge',
     'pre-push',
-    'pre-receive',
     'update',
-    'proc-receive',
-    'post-receive',
     'post-update',
-    'reference-transaction',
-    'push-to-checkout',
-    'pre-auto-gc',
-    'post-rewrite',
-    'sendemail-validate',
-    'fsmonitor-watchman',
-    'p4-changelist',
-    'p4-prepare-changelist',
-    'p4-post-changelist',
-    'p4-pre-submit',
-    'post-index-change',
 ]
 
-exports.isSupportedHook = hook => supportedHooks.includes(hook)
+exports.isSupportedHook = hook => this.supportedHooks.includes(hook)
 
 exports.husky = ({ command, hookType, hookCmd, callback }) => {
-    if (hookType && !this.isSupportedHook(hookType)) {
-        exit(1, 'Unsupported hook')
-    }
-
     const cmd = 'husky'
     const cwd = PACKAGE_ROOT
     const args = [

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -73,27 +73,33 @@ function copy(from, to, { overwrite = false, backup = false }) {
         fs.ensureDirSync(path.dirname(to))
 
         if (exists) {
-            if (backup) {
+            if (backup && !replace) {
                 const toNew = to.concat('.new')
-                log.print(
-                    `Existing config, installing as: ${path.relative(
-                        CONSUMING_ROOT,
-                        toNew
-                    )}`
+                log.debug(
+                    'Existing config found, use --overwrite or manually merge with:'
                 )
+                log.print(`${path.relative(CONSUMING_ROOT, toNew)}`)
                 fs.copySync(from, toNew, { overwrite: true })
                 return
             }
 
             if (replace) {
-                log.print(`Installing: ${path.relative(CONSUMING_ROOT, to)}`)
+                log.debug('Overwriting existing configuration:')
+                log.print(`${path.relative(CONSUMING_ROOT, to)}`)
                 fs.copySync(from, to, { overwrite: true })
                 return
             } else {
-                log.print(`Skip existing: ${path.relative(CONSUMING_ROOT, to)}`)
+                log.print(
+                    `Skip existing config file: ${path.relative(
+                        CONSUMING_ROOT,
+                        to
+                    )}`
+                )
                 return
             }
         } else {
+            log.debug('Configuration file added:')
+            log.print(`${path.relative(CONSUMING_ROOT, to)}`)
             fs.copySync(from, to, { overwrite: replace })
         }
     } catch (err) {


### PR DESCRIPTION
This adds support for more tools:

- EditorConfig
- Prettier
- ls-lint
- GitHub
  - Stale
  - Dependabot
  - Semantic Pull Requests
  - Workflows
    - NodeJs
    - App
    - Lib

Now uses the cli-helpers-engine cache to download the workflows directly
from dhis2/workflows.
