### PR TITLE
fix(ls-lint): improve configuration template to fit most projects

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,10 +1,19 @@
 ls:
-    src:
-        .dir: kebab-case
-        .js: kebab-case
-        .ts: kebab-case
+    ./**/{src,cypress,lib}:
         .css: kebab-case
+        .module.css: kebab-case
+        .feature: kebab-case
+        .js: kebab-case
+        .stories.js: kebab-case
+        .stories.e2e.js: kebab-case
+        .styles.js: kebab-case
+        .test.js: kebab-case
+        .jsx: kebab-case
+        .ts: kebab-case
+        .tsx: kebab-case
         .d.ts: kebab-case
 
 ignore:
     - node_modules
+    - .d2
+    - build

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,17 +1,9 @@
 ls:
     ./**/{src,cypress,lib}:
-        .css: kebab-case
-        .module.css: kebab-case
-        .feature: kebab-case
-        .js: kebab-case
-        .stories.js: kebab-case
-        .stories.e2e.js: kebab-case
-        .styles.js: kebab-case
-        .test.js: kebab-case
-        .jsx: kebab-case
-        .ts: kebab-case
-        .tsx: kebab-case
-        .d.ts: kebab-case
+        .dir: kebab-case
+
+    ./**/node_modules:
+        .dir: regex:.*
 
 ignore:
     - node_modules

--- a/templates/ls-lint-base.yml
+++ b/templates/ls-lint-base.yml
@@ -1,12 +1,19 @@
 ls:
-    src/:
-        .dir: kebab-case
-
-    .js: kebab-case
-    .ts: kebab-case
-    .css: kebab-case
-    .d.ts: kebab-case
+    ./**/{src,cypress,lib}:
+        .css: kebab-case
+        .module.css: kebab-case
+        .feature: kebab-case
+        .js: kebab-case
+        .stories.js: kebab-case
+        .stories.e2e.js: kebab-case
+        .styles.js: kebab-case
+        .test.js: kebab-case
+        .jsx: kebab-case
+        .ts: kebab-case
+        .tsx: kebab-case
+        .d.ts: kebab-case
 
 ignore:
     - node_modules
     - .d2
+    - build

--- a/templates/ls-lint-base.yml
+++ b/templates/ls-lint-base.yml
@@ -1,17 +1,9 @@
 ls:
     ./**/{src,cypress,lib}:
-        .css: kebab-case
-        .module.css: kebab-case
-        .feature: kebab-case
-        .js: kebab-case
-        .stories.js: kebab-case
-        .stories.e2e.js: kebab-case
-        .styles.js: kebab-case
-        .test.js: kebab-case
-        .jsx: kebab-case
-        .ts: kebab-case
-        .tsx: kebab-case
-        .d.ts: kebab-case
+        .dir: kebab-case
+
+    ./**/node_modules:
+        .dir: regex:.*
 
 ignore:
     - node_modules


### PR DESCRIPTION
I have tested this a bit and I think it will pick up bad file names correctly in most cases. However, there is still a problem for monorepos, for example `./package-name/node_modules/src/BAD_FILE.js` is still going to be flagged up as a violation.

I tried adding an ignore line with a glob to combat this, but this didn't seem to have any effect:
```
ignore:
    - node_modules
    - ./**/node_modules
```
Explicitely ignoring the `node_modules` folder did have the desired effect though: 
```
    - node_modules
    - package-name/node_modules
```
Since we can't know the package names upfront, I think we simply need to accept that some manual attention will be required for monorepos.