### PR TITLE
feat(eslint): enforce file extensions within the import path

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -51,5 +51,6 @@ module.exports = {
             },
         ],
         curly: ['error'],
+        'import/extensions': ['error', 'ignorePackages'],
     },
 }


### PR DESCRIPTION
This will enforce explicit imports. Unfortunately there doesn't seem to be any auto fixing.
See [this Slack thread](https://dhis2.slack.com/archives/CPGUFVC56/p1624366840180000) for more background info.