### PR TITLE
fix: print summary error message

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -39,7 +39,12 @@ exports.jscmd = yargs =>
                 fsHandler(argv, statusCode)
             }
 
-            exit(statusCode())
+            exit(
+                statusCode(),
+                `Failed to ${
+                    argv.apply ? 'apply' : 'verify'
+                } code style, see above output for details.`
+            )
         }
     )
 


### PR DESCRIPTION
Provide a log message when the `apply` and `check` commands fail that make it clear that all checks did not pass.

When running `check`:

```sh
javascript > eslint 

/home/varl/dev/dhis2/cli/style/src/commands/types/javascript.js
  12:1   error  Function 'foo' has too many parameters (4). Maximum allowed is 3  max-params
  12:10  error  'foo' is defined but never used                                   no-unused-vars
  12:14  error  'fuz' is defined but never used                                   no-unused-vars
  12:19  error  'buz' is defined but never used                                   no-unused-vars
  12:24  error  'fiz' is defined but never used                                   no-unused-vars
  12:29  error  'biz' is defined but never used                                   no-unused-vars

✖ 6 problems (6 errors, 0 warnings)

javascript > prettier 
Checking formatting...
[warn] src/commands/check.js
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
 
structured-text > prettier 
Checking formatting...
All matched files use Prettier code style!
 
[ERROR] Failed to verify code style, see above output for details. 
```

When running `apply`:

```sh
javascript > eslint 

/home/varl/dev/dhis2/cli/style/src/commands/types/javascript.js
  12:1   error  Function 'foo' has too many parameters (4). Maximum allowed is 3  max-params
  12:10  error  'foo' is defined but never used                                   no-unused-vars
  12:14  error  'fuz' is defined but never used                                   no-unused-vars
  12:19  error  'buz' is defined but never used                                   no-unused-vars
  12:24  error  'fiz' is defined but never used                                   no-unused-vars
  12:29  error  'biz' is defined but never used                                   no-unused-vars

✖ 6 problems (6 errors, 0 warnings)

javascript > prettier 
Checking formatting...
[warn] src/commands/check.js
[warn] Code style issues fixed in the above file(s).
 
structured-text > prettier 
Checking formatting...
All matched files use Prettier code style!
 
[ERROR] Failed to apply code style, see above output for details. 
```