### PR TITLE
refactor: replace deprecated jsxBracketSameLine with bracketSameLine

### DIFF
--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -6,7 +6,7 @@ module.exports = {
     singleQuote: true,
     trailingComma: 'es5',
     bracketSpacing: true,
-    jsxBracketSameLine: false,
+    bracketSameLine: false,
     jsxSingleQuote: false,
     arrowParens: 'avoid',
     rangeStart: 0,


### PR DESCRIPTION
The prettier config [`jsxBracketSameLine`](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets) has been deprecated in favour of `bracketSameLine`.