### PR TITLE
fix: bump ls-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@commitlint/cli": "^12.1.4",
         "@commitlint/config-conventional": "^13.1.0",
         "@dhis2/cli-helpers-engine": "^3.0.0",
-        "@ls-lint/ls-lint": "^1.9.2",
+        "@ls-lint/ls-lint": "^1.10.0",
         "babel-eslint": "^10.1.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,7 +448,7 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@ls-lint/ls-lint@^1.9.2":
+"@ls-lint/ls-lint@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.10.0.tgz#cad20085edc010a3e938aa01bb66d05e5e12b3f3"
   integrity sha512-C1vrI8zFp/28CiqCQHtfu/GqUg2iLYZqtlJHCYfqlg6OJopv7lHAPS0rzk06Ev1121yj4Gi/GmXMBlF+j35DcQ==


### PR DESCRIPTION
Bump ls-lint to 1.10.0 to avoid an error on arm64 cpus