### PR TITLE
fix: add missing dep for eslint-plugin-react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-react": "^7.31.10",
+        "eslint-plugin-react-hooks": "^4.6.2",
         "fast-glob": "^3.2.5",
         "find-up": "^5.0.0",
         "fs-extra": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,6 +1792,11 @@ eslint-plugin-import@^2.22.1:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
+eslint-plugin-react-hooks@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
+  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+
 eslint-plugin-react@^7.31.10:
   version "7.31.10"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"


### PR DESCRIPTION
Noticed that this was missing a dependency `eslint-plugin-react-hooks`, but it was hidden since it was piggy-backing on the dependency from `react-scripts`. In the platform, after removing `react-scripts`, this failed to run (see `git` logs below).

Adding the plugin as a dev dependency in the platform repo fixed it, so I'm confident adding the dep in here will fix it for consumers 👍 

```
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
yarn run v1.22.19
$ /Users/kai/dev/dhis2/app-platform/node_modules/.bin/d2-style check --staged
javascript > eslint 

Oops! Something went wrong! :(

ESLint: 7.32.0

ESLint couldn't find the plugin "eslint-plugin-react-hooks".

(The package "eslint-plugin-react-hooks" was not found when loaded as a Node module from the directory "/Users/kai/dev/dhis2/app-platform/node_modules/@dhis2/cli-style".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install eslint-plugin-react-hooks@latest --save-dev

The plugin "eslint-plugin-react-hooks" was referenced from the config file in ".eslintrc.js » /Users/kai/dev/dhis2/app-platform/node_modules/@dhis2/cli-style/config/eslint-react.config.js".

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

javascript > prettier 
Checking formatting...
All matched files use Prettier code style!
 
structured-text > prettier 
Checking formatting...
All matched files use Prettier code style!
 
 
[ERROR] Failed to verify code style, see above output for details. 
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky - pre-commit hook exited with code 2 (error)
```