### PR TITLE
chore: mention stylelint in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,12 @@ To add prettier configuration:
 yarn d2-style add prettier
 ```
 
+To add stylelint configuration:
+
+```sh
+yarn d2-style add stylelint
+```
+
 To add Git hooks, the format is:
 
 ```sh


### PR DESCRIPTION
This updates cli-style documentation to mention stylelint in getting started guide.