### PR TITLE
fix(eslint-react-config): handle files with .jsx extensions

### DIFF
--- a/config/eslint-react.config.js
+++ b/config/eslint-react.config.js
@@ -10,9 +10,11 @@ module.exports = {
     ],
 
     settings: {
-        react: {
-            version: 'detect',
-        },
+        react: { version: 'detect' },
+        // Prevents "error: unable to resolve module X" for .jsx files 
+        // if .jsx extension isn't used, e.g.
+        // `import Component from './component'`
+        'import/resolver': { node: { extensions: ['.js', '.jsx'] } },
     },
 
     rules: {

--- a/config/eslint-react.config.js
+++ b/config/eslint-react.config.js
@@ -11,7 +11,7 @@ module.exports = {
 
     settings: {
         react: { version: 'detect' },
-        // Prevents "error: unable to resolve module X" for .jsx files 
+        // Prevents "error: unable to resolve module X" for .jsx files
         // if .jsx extension isn't used, e.g.
         // `import Component from './component'`
         'import/resolver': { node: { extensions: ['.js', '.jsx'] } },


### PR DESCRIPTION
If file extensions aren't used for some reason (workspace preference, for example), ESLint can show an error like `Unable to resolve path to module './components/Routes'` when trying to import from `./components/Routes.jsx`. This config change fixes the resolver

I think for .tsx files, that's handled by the typescript config

Example of before and after, using local ESLint config:

![Screenshot 2025-01-24 at 10 51 29](https://github.com/user-attachments/assets/b1e24d7b-33e9-41c1-8acb-7e0a24794492)

![Screenshot 2025-01-24 at 10 51 37](https://github.com/user-attachments/assets/1c50d25e-e9f2-418c-af78-bd7820d3ad56)
