### PR TITLE
fix: update commitlint.config header max length

### DIFF
--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -1,11 +1,8 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-<<<<<<< HEAD
         'header-max-length': [2, 'always', 120],
-=======
         'body-max-line-length': [1, 'always', 100],
->>>>>>> origin/master
     },
     /*
      * Ignore commits that don't contribute to a release. Release


### PR DESCRIPTION
Update the commit header length so that it can include more info now that we are publishing change logs to GitHub

you can test locally with `echo "fix(dimensions-panel): prevent movement of multi-line content in dimension items on hover [DHIS2-19046] (#1762)" | npx commitlint` from this branch and `cd config` .. the output for running it with the new limit and without, are in the screenshots:


| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c302a8e3-35be-4228-bf06-014551912a3b) | ![image](https://github.com/user-attachments/assets/3b551475-4357-4239-9556-baeb40fabf2f) |

[DHIS2-19046]: https://dhis2.atlassian.net/browse/DHIS2-19046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ