### PR TITLE
fix: ignore '[skip ci]' commits

### DIFF
--- a/config/commitlint.config.js
+++ b/config/commitlint.config.js
@@ -9,5 +9,5 @@ module.exports = {
      * commits often exceed the max. amount of characters because
      * of the appended changelog. This ignores those commits.
      */
-    ignores: [(commit) => commit.includes('[skip release]')],
+    ignores: [(commit) => commit.includes('[skip release]') || commit.includes('[skip ci]') ],
 }


### PR DESCRIPTION
This  is  necessary, for example, when merging from beta or alpha branches where the release commits break the rules and have [skip  ci] (we already do the same with [skip release])

